### PR TITLE
Opt-out of strcpy_s for gnu c based compilers

### DIFF
--- a/client/src/WebClient.cpp
+++ b/client/src/WebClient.cpp
@@ -11,6 +11,10 @@
 #define USE_STRCPY_S 1
 #endif
 
+#ifdef __GNUC__
+#define USE_STRCPY_S 1
+#endif
+
 #ifndef USE_STRCPY_S
 #define USE_STRCPY_S 0
 #endif


### PR DESCRIPTION
Fixes builds on Linux using gcc/clang, there might be a better way to opt-in/out by detecting capabilities directly (I found something about __STDC_WANT_LIB_EXT1__ and __STDC_LIB_EXT1__ [here](https://stackoverflow.com/questions/40045973/strcpy-s-not-working-with-gcc)), and I haven't tested this on other platforms. Would not be surprised if this removes the need for the Apple and Android detection.